### PR TITLE
fix: correct type for UserMediaListEntry/customLists

### DIFF
--- a/nifty_anilist/prebuilt/media_list.py
+++ b/nifty_anilist/prebuilt/media_list.py
@@ -100,7 +100,7 @@ class UserMediaListEntry(BaseModel):
     advancedScores: Optional[Dict[str, Any]]
     completedAt: Timestamp
     createdAt: int
-    customLists: Optional[Dict[str, Any]]
+    customLists: Optional[list[Dict[str, Any]]]
     hiddenFromStatusLists: bool
     id: int
     media: UserMediaEntry


### PR DESCRIPTION
Added list wrapping around the customLists dict. Previous version was erroring when attempting to parse.